### PR TITLE
Fix Next.js build by removing empty interface

### DIFF
--- a/Saas-Project/frontend/src/components/ui/input.tsx
+++ b/Saas-Project/frontend/src/components/ui/input.tsx
@@ -2,8 +2,7 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {


### PR DESCRIPTION
## Summary
- fix InputProps declaration to satisfy ESLint

## Testing
- `npm test`
- `npm run build`
- `cargo test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882a48af1c48324a9504d76cf4570a2