### PR TITLE
Implement token refresh and profile retrieval

### DIFF
--- a/Saas-Project/backend/src/infrastructure/web/handlers/auth.rs
+++ b/Saas-Project/backend/src/infrastructure/web/handlers/auth.rs
@@ -1,14 +1,11 @@
-use axum::{
-    extract::State,
-    http::StatusCode,
-    response::Json,
-};
+use axum::{extract::State, http::StatusCode, response::Json};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::Arc;
+use uuid::Uuid;
 
 use crate::domain::entities::{User, UserRole};
-use crate::domain::value_objects::{Email};
+use crate::domain::value_objects::{Email, UserId};
 
 // For now, use a type alias since AppState isn't defined yet
 type AppState = crate::AppContext;
@@ -56,14 +53,15 @@ pub async fn register(
     Json(payload): Json<RegisterDto>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
     // Parse email
-    let email = Email::new(&payload.email)
-        .map_err(|err| (
+    let email = Email::new(&payload.email).map_err(|err| {
+        (
             StatusCode::BAD_REQUEST,
             Json(json!({
                 "error": "Invalid email format",
                 "details": err
-            }))
-        ))?;
+            })),
+        )
+    })?;
 
     // Parse role or default to UmkmOwner
     let role = match payload.role.as_deref() {
@@ -73,32 +71,32 @@ pub async fn register(
     };
 
     // Hash password
-    let password_hash = state.auth_service.hash_password(&payload.password)
-        .map_err(|err| (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({
-                "error": "Failed to process password",
-                "details": err.to_string()
-            }))
-        ))?;
+    let password_hash = state
+        .auth_service
+        .hash_password(&payload.password)
+        .map_err(|err| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({
+                    "error": "Failed to process password",
+                    "details": err.to_string()
+                })),
+            )
+        })?;
 
     // Create user
-    let user = User::new(
-        email,
-        password_hash,
-        payload.full_name,
-        role,
-    );
+    let user = User::new(email, password_hash, payload.full_name, role);
 
     // Save user to database
-    state.user_repository.save(&user).await
-        .map_err(|err| (
+    state.user_repository.save(&user).await.map_err(|err| {
+        (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({
                 "error": "Failed to create user",
                 "details": err.to_string()
-            }))
-        ))?;
+            })),
+        )
+    })?;
 
     Ok(Json(json!({
         "message": "User registered successfully",
@@ -113,46 +111,58 @@ pub async fn login(
     Json(payload): Json<LoginDto>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
     // Parse email
-    let email = Email::new(&payload.email)
-        .map_err(|err| (
+    let email = Email::new(&payload.email).map_err(|err| {
+        (
             StatusCode::BAD_REQUEST,
             Json(json!({
                 "error": "Invalid email format",
                 "details": err
-            }))
-        ))?;
+            })),
+        )
+    })?;
 
     // Find user by email
-    let mut user = state.user_repository.find_by_email(&email).await
-        .map_err(|err| (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({
-                "error": "Database error",
-                "details": err.to_string()
-            }))
-        ))?
-        .ok_or_else(|| (
-            StatusCode::UNAUTHORIZED,
-            Json(json!({
-                "error": "Invalid credentials"
-            }))
-        ))?;
+    let mut user = state
+        .user_repository
+        .find_by_email(&email)
+        .await
+        .map_err(|err| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({
+                    "error": "Database error",
+                    "details": err.to_string()
+                })),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({
+                    "error": "Invalid credentials"
+                })),
+            )
+        })?;
 
     // Verify password
-    let is_valid = state.auth_service.verify_password(&payload.password, &user.password_hash)
-        .map_err(|_| (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({
-                "error": "Internal server error"
-            }))
-        ))?;
+    let is_valid = state
+        .auth_service
+        .verify_password(&payload.password, &user.password_hash)
+        .map_err(|_| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({
+                    "error": "Internal server error"
+                })),
+            )
+        })?;
 
     if !is_valid {
         return Err((
             StatusCode::UNAUTHORIZED,
             Json(json!({
                 "error": "Invalid credentials"
-            }))
+            })),
         ));
     }
 
@@ -162,32 +172,34 @@ pub async fn login(
             StatusCode::FORBIDDEN,
             Json(json!({
                 "error": "Account not active or email not verified"
-            }))
+            })),
         ));
     }
 
     // Update last login
     user.update_last_login();
-    
+
     // Save updated user back to database
-    state.user_repository.save(&user).await
-        .map_err(|err| (
+    state.user_repository.save(&user).await.map_err(|err| {
+        (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({
                 "error": "Failed to update login time",
                 "details": err.to_string()
-            }))
-        ))?;
+            })),
+        )
+    })?;
 
     // Generate tokens
-    let tokens = state.auth_service.generate_tokens(&user)
-        .map_err(|err| (
+    let tokens = state.auth_service.generate_tokens(&user).map_err(|err| {
+        (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({
                 "error": "Failed to generate tokens",
                 "details": err.to_string()
-            }))
-        ))?;
+            })),
+        )
+    })?;
 
     Ok(Json(json!({
         "access_token": tokens.access_token,
@@ -203,15 +215,33 @@ pub async fn login(
 }
 
 /// Get current user profile
-pub async fn get_profile() -> Result<Json<UserProfileResponse>, (StatusCode, Json<ErrorResponse>)> {
-    // For now, return a placeholder response
-    // TODO: Extract user ID from JWT token in middleware and pass it here
+pub async fn get_profile(
+    State(state): State<Arc<AppState>>,
+    auth_user: crate::infrastructure::web::middleware::auth::AuthenticatedUser,
+) -> Result<Json<UserProfileResponse>, (StatusCode, Json<serde_json::Value>)> {
+    let user = state
+        .user_repository
+        .find_by_id(&auth_user.user_id)
+        .await
+        .map_err(|err| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": err.to_string() })),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": "User not found" })),
+            )
+        })?;
+
     let response = UserProfileResponse {
-        id: "placeholder-user-id".to_string(),
-        email: "user@example.com".to_string(),
-        role: "umkm_owner".to_string(),
-        is_verified: true,
-        created_at: chrono::Utc::now(),
+        id: user.id.to_string(),
+        email: user.email.as_str().to_string(),
+        role: user.role.to_string(),
+        is_verified: user.email_verified_at.is_some(),
+        created_at: user.created_at,
     };
 
     Ok(Json(response))
@@ -222,41 +252,86 @@ pub async fn refresh_token(
     State(state): State<Arc<AppState>>,
     Json(payload): Json<serde_json::Value>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
-    let refresh_token = payload.get("refresh_token")
+    let refresh_token = payload
+        .get("refresh_token")
         .and_then(|v| v.as_str())
-        .ok_or_else(|| (
-            StatusCode::BAD_REQUEST,
-            Json(json!({
-                "error": "Missing refresh token"
-            }))
-        ))?;
+        .ok_or_else(|| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(json!({
+                    "error": "Missing refresh token"
+                })),
+            )
+        })?;
 
     // Validate refresh token
-    let claims = state.auth_service.validate_token(refresh_token)
-        .map_err(|err| (
-            StatusCode::UNAUTHORIZED,
-            Json(json!({
-                "error": "Invalid refresh token",
-                "details": err.to_string()
-            }))
-        ))?;
+    let claims = state
+        .auth_service
+        .validate_token(refresh_token)
+        .map_err(|err| {
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({
+                    "error": "Invalid refresh token",
+                    "details": err.to_string()
+                })),
+            )
+        })?;
 
-    // TODO: Get user from database and generate new tokens
-    // For now, return a placeholder response
-    let user_id = &claims.sub;
+    let user_id = Uuid::parse_str(&claims.sub).map_err(|_| {
+        (
+            StatusCode::UNAUTHORIZED,
+            Json(json!({"error": "Invalid token claims"})),
+        )
+    })?;
+
+    let user = state
+        .user_repository
+        .find_by_id(&UserId(user_id))
+        .await
+        .map_err(|err| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": err.to_string() })),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": "User not found" })),
+            )
+        })?;
+
+    let tokens = state.auth_service.generate_tokens(&user).map_err(|err| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": err.to_string() })),
+        )
+    })?;
 
     Ok(Json(json!({
-        "access_token": "new_access_token_placeholder",
-        "refresh_token": "new_refresh_token_placeholder",
-        "expires_at": chrono::Utc::now() + chrono::Duration::minutes(15),
-        "user_id": user_id
+        "access_token": tokens.access_token,
+        "refresh_token": tokens.refresh_token,
+        "expires_at": tokens.expires_at,
+        "user": {
+            "id": user.id.to_string(),
+            "email": user.email.as_str(),
+            "full_name": user.full_name,
+            "role": user.role.to_string()
+        }
     })))
 }
 
 /// Logout endpoint
-pub async fn logout() -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
-    // TODO: Invalidate refresh token in database
-    
+pub async fn logout(
+    State(state): State<Arc<AppState>>,
+    auth_user: crate::infrastructure::web::middleware::auth::AuthenticatedUser,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    if let Some(cache) = &state.cache_service {
+        let pattern = format!("refresh:{}:*", auth_user.user_id);
+        let _ = cache.delete_by_pattern(&pattern).await;
+    }
+
     Ok(Json(json!({
         "message": "Logged out successfully"
     })))
@@ -266,14 +341,17 @@ pub async fn logout() -> Result<Json<serde_json::Value>, (StatusCode, Json<serde
 pub async fn request_password_reset(
     Json(payload): Json<serde_json::Value>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
-    let _email = payload.get("email")
+    let _email = payload
+        .get("email")
         .and_then(|v| v.as_str())
-        .ok_or_else(|| (
-            StatusCode::BAD_REQUEST,
-            Json(json!({
-                "error": "Missing email"
-            }))
-        ))?;
+        .ok_or_else(|| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(json!({
+                    "error": "Missing email"
+                })),
+            )
+        })?;
 
     Ok(Json(json!({
         "message": "If an account with this email exists, a password reset link has been sent"


### PR DESCRIPTION
## Summary
- extract authenticated user from request for profile
- refresh tokens properly using stored user info
- invalidate cached refresh tokens on logout

## Testing
- `cargo test --no-run`

------
https://chatgpt.com/codex/tasks/task_e_6882affb18708324bcb30ef7cab92cb7