### PR TITLE
Add license file upload

### DIFF
--- a/Saas-Project/backend/Cargo.lock
+++ b/Saas-Project/backend/Cargo.lock
@@ -390,6 +390,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime 0.3.17",
+ "multer",
  "percent-encoding 2.3.1",
  "pin-project-lite",
  "rustversion",

--- a/Saas-Project/backend/Cargo.toml
+++ b/Saas-Project/backend/Cargo.toml
@@ -7,7 +7,7 @@ description = "Backend API for Indonesian SME licensing and business management 
 
 [dependencies]
 # Web Framework (Axum as recommended in document)
-axum = { version = "0.7", features = ["macros"] }
+axum = { version = "0.7", features = ["macros", "multipart"] }
 axum-extra = { version = "0.9", features = ["cookie", "typed-header"] }
 tower = "0.4"
 tower-http = { version = "0.5", features = ["cors", "trace", "compression-br", "fs"] }

--- a/Saas-Project/backend/src/main.rs
+++ b/Saas-Project/backend/src/main.rs
@@ -9,6 +9,7 @@ use tower_http::{
     compression::CompressionLayer,
     cors::{Any, CorsLayer},
     trace::TraceLayer,
+    services::ServeDir,
 };
 use tracing::{info, instrument, warn};
 
@@ -168,6 +169,8 @@ async fn create_app(state: AppState) -> Router {
     router = router
         // Health check endpoint
         .route("/health", get(health_check))
+        // Static file serving for uploads
+        .nest_service("/uploads", ServeDir::new(state.config.upload_dir.clone()))
         // API routes
         .nest("/api/v1", create_api_routes());
 


### PR DESCRIPTION
## Summary
- support axum multipart feature
- expose uploads directory via ServeDir
- implement license document upload handler

## Testing
- `cargo check --manifest-path backend/Cargo.toml`
- `cargo test --manifest-path backend/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_6882b4ac2bfc8324b9def813e56faa3b