### PR TITLE
Add stub modules for license and payment services

### DIFF
--- a/Saas-Project/backend/src/services/license_processing.rs
+++ b/Saas-Project/backend/src/services/license_processing.rs
@@ -1,0 +1,25 @@
+use crate::domain::licenses::{ApplicationStatus, License};
+use crate::shared::errors::{AppError, AppResult};
+
+/// Service responsible for handling license workflows
+#[derive(Debug, Default)]
+pub struct LicenseProcessingService;
+
+impl LicenseProcessingService {
+    /// Create a new instance of the service
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Submit a license application. This is a stub implementation that simply
+    /// transitions the license into the `Submitted` state if possible.
+    pub fn submit(&self, mut license: License) -> AppResult<License> {
+        license.submit().map_err(AppError::Validation)?;
+        Ok(license)
+    }
+
+    /// Return the current status of a license
+    pub fn status(&self, license: &License) -> ApplicationStatus {
+        license.application_status.clone()
+    }
+}

--- a/Saas-Project/backend/src/services/license_processing_models.rs
+++ b/Saas-Project/backend/src/services/license_processing_models.rs
@@ -1,0 +1,21 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::domain::licenses::{ApplicationStatus, LicenseType, PriorityLevel};
+
+/// Request payload for submitting a license application
+#[derive(Debug, Deserialize)]
+pub struct LicenseApplicationRequest {
+    pub company_id: Uuid,
+    pub license_type: LicenseType,
+    pub title: String,
+    pub description: Option<String>,
+    pub priority: Option<PriorityLevel>,
+}
+
+/// Simple response returned after creating a license application
+#[derive(Debug, Serialize)]
+pub struct LicenseApplicationResponse {
+    pub id: Uuid,
+    pub status: ApplicationStatus,
+}

--- a/Saas-Project/backend/src/services/mod.rs
+++ b/Saas-Project/backend/src/services/mod.rs
@@ -1,1 +1,4 @@
 pub mod auth;
+pub mod license_processing;
+pub mod license_processing_models;
+pub mod payment;

--- a/Saas-Project/backend/src/services/payment.rs
+++ b/Saas-Project/backend/src/services/payment.rs
@@ -1,0 +1,21 @@
+use crate::domain::value_objects::Money;
+use crate::shared::errors::{AppError, AppResult};
+
+/// Service for processing payments. This is a very small stub used in tests and
+/// example code. Real integrations with payment gateways would live here.
+#[derive(Debug, Default)]
+pub struct PaymentService;
+
+impl PaymentService {
+    /// Create a new service instance
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Charge a payment of the given amount. The default implementation simply
+    /// returns `Ok(())` and does not perform any external calls.
+    pub fn charge(&self, amount: Money) -> AppResult<()> {
+        let _ = amount;
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- create `license_processing` service and supporting models
- stub out a simple `PaymentService`
- expose the new modules in the services module

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6888d821c0d08324aff36a96755f6225