### PR TITLE
Fix warnings after cargo check

### DIFF
--- a/Saas-Project/backend/src/infrastructure/repositories/in_memory_user_repository.rs
+++ b/Saas-Project/backend/src/infrastructure/repositories/in_memory_user_repository.rs
@@ -19,6 +19,7 @@ pub struct InMemoryUserRepository {
 
 impl InMemoryUserRepository {
     /// Create a new empty in-memory user repository
+    #[allow(dead_code)]
     pub fn new() -> Self {
         Self {
             users: Arc::new(Mutex::new(HashMap::new())),
@@ -26,6 +27,7 @@ impl InMemoryUserRepository {
     }
 
     /// Create a new in-memory user repository with some initial data
+    #[allow(dead_code)]
     pub fn with_users(users: Vec<User>) -> Self {
         let mut map = HashMap::new();
         for user in users {

--- a/Saas-Project/backend/src/middleware/rate_limiter.rs
+++ b/Saas-Project/backend/src/middleware/rate_limiter.rs
@@ -20,6 +20,7 @@ use crate::infrastructure::web::handlers::AppState;
 // Simple in-memory rate limiter
 // For production, this would be better implemented with Redis
 #[derive(Clone)]
+#[allow(dead_code)]
 pub struct RateLimiter {
     // Map of IP addresses to a list of request timestamps
     requests: Arc<Mutex<HashMap<IpAddr, Vec<Instant>>>>,
@@ -38,6 +39,7 @@ impl RateLimiter {
         }
     }
 
+    #[allow(dead_code)]
     async fn is_rate_limited(&self, ip: IpAddr) -> bool {
         let now = Instant::now();
         let window = Duration::from_secs(self.window_secs);

--- a/Saas-Project/backend/src/services/license_processing.rs
+++ b/Saas-Project/backend/src/services/license_processing.rs
@@ -7,18 +7,21 @@ pub struct LicenseProcessingService;
 
 impl LicenseProcessingService {
     /// Create a new instance of the service
+    #[allow(dead_code)]
     pub fn new() -> Self {
         Self
     }
 
     /// Submit a license application. This is a stub implementation that simply
     /// transitions the license into the `Submitted` state if possible.
+    #[allow(dead_code)]
     pub fn submit(&self, mut license: License) -> AppResult<License> {
         license.submit().map_err(AppError::Validation)?;
         Ok(license)
     }
 
     /// Return the current status of a license
+    #[allow(dead_code)]
     pub fn status(&self, license: &License) -> ApplicationStatus {
         license.application_status.clone()
     }

--- a/Saas-Project/backend/src/services/license_processing_models.rs
+++ b/Saas-Project/backend/src/services/license_processing_models.rs
@@ -5,6 +5,7 @@ use crate::domain::licenses::{ApplicationStatus, LicenseType, PriorityLevel};
 
 /// Request payload for submitting a license application
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 pub struct LicenseApplicationRequest {
     pub company_id: Uuid,
     pub license_type: LicenseType,
@@ -15,6 +16,7 @@ pub struct LicenseApplicationRequest {
 
 /// Simple response returned after creating a license application
 #[derive(Debug, Serialize)]
+#[allow(dead_code)]
 pub struct LicenseApplicationResponse {
     pub id: Uuid,
     pub status: ApplicationStatus,

--- a/Saas-Project/backend/src/services/payment.rs
+++ b/Saas-Project/backend/src/services/payment.rs
@@ -1,5 +1,5 @@
 use crate::domain::value_objects::Money;
-use crate::shared::errors::{AppError, AppResult};
+use crate::shared::errors::AppResult;
 
 /// Service for processing payments. This is a very small stub used in tests and
 /// example code. Real integrations with payment gateways would live here.
@@ -7,6 +7,7 @@ use crate::shared::errors::{AppError, AppResult};
 pub struct PaymentService;
 
 impl PaymentService {
+    #[allow(dead_code)]
     /// Create a new service instance
     pub fn new() -> Self {
         Self
@@ -14,6 +15,7 @@ impl PaymentService {
 
     /// Charge a payment of the given amount. The default implementation simply
     /// returns `Ok(())` and does not perform any external calls.
+    #[allow(dead_code)]
     pub fn charge(&self, amount: Money) -> AppResult<()> {
         let _ = amount;
         Ok(())


### PR DESCRIPTION
## Summary
- silence warnings in repository implementations and services
- remove unused import in PaymentService

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6888da84a9b483248bca2f7f9cae676e